### PR TITLE
add a no-op service worker for previous installations

### DIFF
--- a/website/static/js/custom.js
+++ b/website/static/js/custom.js
@@ -8,6 +8,7 @@ window.addEventListener('load', function() {
   clipboard.on('success', function(event) {
     event.clearSelection();
   })
+  navigator.serviceWorker.register('/service-worker.js');
 })
 
 function setpp(event) {

--- a/website/static/service-worker.js
+++ b/website/static/service-worker.js
@@ -1,0 +1,22 @@
+// A simple, no-op service worker that takes immediate control.
+
+self.addEventListener('install', () => {
+    // Skip over the "waiting" lifecycle state, to ensure that our
+    // new service worker is activated immediately, even if there's
+    // another tab open controlled by our older service worker code.
+    self.skipWaiting();
+});
+
+/*
+self.addEventListener('activate', () => {
+  // Optional: Get a list of all the current open windows/tabs under
+  // our service worker's control, and force them to reload.
+  // This can "unbreak" any open windows/tabs as soon as the new
+  // service worker activates, rather than users having to manually reload.
+  self.clients.matchAll({type: 'window'}).then(windowClients => {
+    windowClients.forEach(windowClient => {
+      windowClient.navigate(windowClient.url);
+    });
+  });
+});
+*/


### PR DESCRIPTION
Previous site had a service worker.

Having no service worker anymore causes issues for people who loaded the site previously
https://github.com/w3c/ServiceWorker/issues/204