### PR TITLE
docs: add web monetization examples

### DIFF
--- a/docs/counter.md
+++ b/docs/counter.md
@@ -4,8 +4,8 @@ title: Micropayment Counter
 sidebar_label: Micropayment Counter
 ---
 
-Web Monetization lets you count exactly how much you made from a given visitor,
-and update that amount in real-time as more micropayments come in. Like any
+Web Monetization lets you count exactly how much you made from a given visitor.
+The amount updates in real-time as more micropayments come in. Like any
 animated effect it should be used sparingly, but it can be a cool way to show
 your visitors exactly how much they're supporting you!
 
@@ -49,26 +49,29 @@ much you've made off of micropayments from a given visitor.
 </body>
 ```
 
-[_You can view this example page here_](/examples/counter.html).
+Load the example page with Web Monetization enabled to see the amount count up.
 
-Load this page with Web Monetization enabled to see the amount count up.
+[_You can view the example page here_](/examples/counter.html).
 
 ## How Does it Work?
+
+If the visitor is Web-monetized (`document.monetization` is defined), we're
+binding the `monetizationprogress` event. `monetizationprogress` contains
+details about the micropayments that occur.
 
 ```js
 if (document.monetization) {
   document.monetization.addEventListener('monetizationprogress', ev => {
 ```
 
-If the visitor is Web Monetized (`document.monetization` is defined), we're
-binding the `monetizationprogress` event. This is different from previous
-examples, where we bound `monetizationstart`.
-
-`monetizationstart` fires once Web Monetization initializes.
+This is different from the [Exclusive Content](./exclusive-content) and
+[Remove Ads](./remove-ads) examples, where we bound `monetizationstart`.
+`monetizationstart` fires when Web Monetization initializes.
 `monetizationprogress` fires every time there's a micropayment from the Web
 Monetization provider to the site.
 
-`monetizationprogress` contains details about the micropayments that occur.
+There's some attributes of the micropayments that don't change, like currency
+details. We set these currency details on the very first micropayment.
 
 ```js
   // initialize currency and scale on first progress event
@@ -78,44 +81,40 @@ Monetization provider to the site.
   }
 ```
 
-There's some attributes of the micropayments that don't change, like currency
-details. We set these currency details on the very first micropayment.
-
 `ev.detail.assetCode` is a three-letter code that describes the currency of the micropayment,
 like `USD`, `EUR`, or `XRP`.
 
-The asset code describes what asset the [Web Monetization
+The asset code describes the asset the [Web Monetization
 receiver](http://localhost:3000/docs/glossary#web-monetization-receiver) is
 denominating their incoming payments in. This often matches the currency your
 wallet account uses, but not always.
 
 The asset code will stay the same for a given payment pointer (your wallet
-should warn you if they change it). It is not affected by the currency that the
-Web Monetization provider uses.
+  provider should warn you if they change it). It is not affected by the
+  currency that the Web Monetization provider uses.
 
 `ev.detail.assetScale` defines how small the units of amount will be on this payment pointer.
 A bigger scale means smaller units. If your scale is 2 and your asset code is USD, then it means
 you need 100 (`10 ** 2`) units to get one dollar.
 
+The amount in `ev.detail.amount` is an integer, which we add to our total.
 
 ```js
   total += Number(ev.detail.amount)
 ```
 
-The amount in `ev.detail.amount` is an integer, which we add to our total.
-
 > Even though `ev.detail.amount` is a string that can represent a number up to
 > 64 bits long in theory (too big for a JavaScript number), it's OK for us to
 > convert it to a JavaScript number here. The micropayment amounts in Web
-> Monetization are far from pushing the limits.  With USD and a scale of 9, for
+> Monetization are far from pushing the limits. With USD and a scale of 9, for
 > instance, it would take around 500,000 years to overflow this number.
+
+Finally, we update the text on the page with our new total. Our total is an
+integer with the total number of indivisible units. We want it to be a more
+readable decimal number, though, so we apply the scale to format it. This
+formatted version of the amount gets written to the `total` span on the page.
 
 ```js
   const formatted = (total * Math.pow(10, -scale)).toFixed(scale)
   document.getElementById('total').innerText = formatted
 ```
-
-Finally we update the text on the page with our new total. Our total is an
-integer with the total number of indivisible units. We want it to be a more
-readable decimal number, though, so we apply the scale to format it. This
-formatted version of the amount gets written to the `total` span on the page.

--- a/docs/counter.md
+++ b/docs/counter.md
@@ -1,0 +1,121 @@
+---
+id: counter
+title: Micropayment Counter
+sidebar_label: Micropayment Counter
+---
+
+Sometimes the question "is this visitor Web Monetized?" has a more complicated
+answer than "yes/no." Sometimes you care about how much money you're making
+from a visitor, and you want to trigger logic on your site depending on the
+amount.
+
+This example shows you how to use the `monetizationprogress` event to count how
+much you've made off of micropayments from a given visitor.
+
+## Code
+
+```html
+<head>
+  <!-- this should be set to your own payment pointer -->
+  <meta name="monetization" content="$twitter.xrptipbot.com/Interledger">
+
+  <script>
+    let total = 0
+    let scale
+
+    if (document.monetization) {
+      document.monetization.addEventListener('monetizationprogress', ev => {
+        // initialize currency and scale on first progress event
+        if (total === 0) {
+          scale = ev.detail.assetScale
+          document.getElementById('currency').innerText = ev.detail.assetCode
+        }
+
+        total += Number(ev.detail.amount)
+
+        const formatted = (total * Math.pow(10, -scale)).toFixed(scale)
+        document.getElementById('total').innerText = formatted
+      })
+    }
+  </script>
+</head>
+
+<body>
+  <p>
+    Thanks to you, I've made
+    <span id="total">nothing (yet)</span>
+    <span id="currency"></span>
+  </p>
+</body>
+```
+
+[_You can view this example page here_](/examples/counter.html).
+
+Load this page with Web Monetization enabled to see the amount count up.
+
+## How Does it Work?
+
+```js
+if (document.monetization) {
+  document.monetization.addEventListener('monetizationprogress', ev => {
+```
+
+If the visitor is Web Monetized (`document.monetization` is defined), we're
+binding the `monetizationprogress` event. This is different from previous
+examples, where we bound `monetizationstart`.
+
+`monetizationstart` fires once Web Monetization initializes.
+`monetizationprogress` fires every time there's a micropayment from the Web
+Monetization provider to the site.
+
+`monetizationprogress` contains details about the micropayments that occur.
+
+```js
+  // initialize currency and scale on first progress event
+  if (total === 0) {
+    scale = ev.detail.assetScale
+    document.getElementById('currency').innerText = ev.detail.assetCode
+  }
+```
+
+There's some attributes of the micropayments that don't change, like currency
+details. We set these currency details on the very first micropayment.
+
+`ev.detail.assetCode` is a three-letter code that describes the currency of the micropayment,
+like `USD`, `EUR`, or `XRP`.
+
+The asset code describes what asset the [Web Monetization
+receiver](http://localhost:3000/docs/glossary#web-monetization-receiver) is
+denominating their incoming payments in. This often matches the currency your
+wallet account uses, but not always.
+
+The asset code will stay the same for a given payment pointer (your wallet
+should warn you if they change it). It is not affected by the currency that the
+Web Monetization provider uses.
+
+`ev.detail.assetScale` defines how small the units of amount will be on this payment pointer.
+A bigger scale means smaller units. If your scale is 2 and your asset code is USD, then it means
+you need 100 (`10 ** 2`) units to get one dollar.
+
+
+```js
+  total += Number(ev.detail.amount)
+```
+
+The amount in `ev.detail.amount` is an integer, which we add to our total.
+
+> Even though `ev.detail.amount` is a string that can represent a number up to
+> 64 bits long in theory (too big for a JavaScript number), it's OK for us to
+> convert it to a JavaScript number here. The micropayment amounts in Web
+> Monetization are far from pushing the limits.  With USD and a scale of 9, for
+> instance, it would take around 500,000 years to overflow this number.
+
+```js
+  const formatted = (total * Math.pow(10, -scale)).toFixed(scale)
+  document.getElementById('total').innerText = formatted
+```
+
+Finally we update the text on the page with our new total. Our total is an
+integer with the total number of indivisible units. We want it to be a more
+readable decimal number, though, so we apply the scale to format it. This
+formatted version of the amount gets written to the `total` span on the page.

--- a/docs/counter.md
+++ b/docs/counter.md
@@ -4,10 +4,10 @@ title: Micropayment Counter
 sidebar_label: Micropayment Counter
 ---
 
-Sometimes the question "is this visitor Web Monetized?" has a more complicated
-answer than "yes/no." Sometimes you care about how much money you're making
-from a visitor, and you want to trigger logic on your site depending on the
-amount.
+Web Monetization lets you count exactly how much you made from a given visitor,
+and update that amount in real-time as more micropayments come in. Like any
+animated effect it should be used sparingly, but it can be a cool way to show
+your visitors exactly how much they're supporting you!
 
 This example shows you how to use the `monetizationprogress` event to count how
 much you've made off of micropayments from a given visitor.

--- a/docs/exclusive-content.md
+++ b/docs/exclusive-content.md
@@ -6,16 +6,16 @@ sidebar_label: Exclusive Content
 
 One of the perks of Web Monetization is that its JavaScript API can be used to
 make your page respond to Web Monetization. You can reward the people who
-support your site by giving Web Monetized viewers exclusive content.
+support your site by giving Web-monetized viewers exclusive content.
 
 
 ## A Basic Example
 
-Web Monetization makes exclusive content easy! This is a very simple example of
-exclusive content that only shows up for Web Monetized visitors:
+Web Monetization makes providing exclusive content easy! This is a very simple example of
+showing exclusive content only to Web-monetized visitors:
 
 > **Careful!** These examples hide content on the client side. A clever user
-> could pretend to be Web Monetized by using the developer console. Examples on
+> could pretend to be Web-monetized by using the developer console. Examples on
 > how to verify Web Monetization from the server side will come soon.
 
 ### Code
@@ -47,54 +47,54 @@ exclusive content that only shows up for Web Monetized visitors:
 </body>
 ```
 
-[_You can view this example page here_](/examples/show_simple.html).
-
-If you view this content with Web Monetization enabled then it will show
+If you view this content with Web Monetization enabled, then the page will show
 "Here's some exclusive content!" once Web Monetization initializes. If you view
-it without Web Monetization then you won't see anything.
+it without Web Monetization, then you won't see anything.
+
+[_You can view the example page here_](/examples/show_simple.html).
 
 ### How Does it Work?
 
 There's only three things this code does. The code is encompassed in the `<script>`
 tag.
 
+First, we check whether `document.monetization` exists in the browser. If it
+doesn't exist, then we can't listen for the `monetizationstart` event to tell
+us when Web Monetization initializes.
+
 ```js
 if (document.monetization) {
 ```
 
-First, we check whether document.monetization exists in this browser. If it
-does not exist then we can't listen for the `monetizationstart` event to tell
-us when Web Monetization initializes.
+Next, we add an event listener to the `document.monetization` object. The
+`monetizationstart` event is emitted when Web Monetization initializes and
+the state goes from `pending` to `started`.
 
 ```js
   document.monetization.addEventListener('monetizationstart', () => {
 ```
 
-Next we add an event listener to the `document.monetization` object. The
-`monetizationstart` event is emitted when Web Monetization initializes and
-the state goes from `pending` to `started`.
+Finally, we select our exclusive content element and make it visible. We defined
+a CSS class that made it hidden, so removing that class will make it visible.
+If you want to do something else when Web Monetization starts, you can replace
+this line. You can trigger any JavaScript, so the sky's the limit.
 
 ```js
       document.getElementById('exclusive').classList.remove('hidden')
 ```
 
-Finally we select our exclusive content element and make it visible. We defined
-a CSS class that made it hidden, so removing that class will make it visible.
-If you want to do something else when Web Monetization starts, you can replace
-this line. You can trigger any JavaScript so the sky's the limit.
-
 ## A Complete Example
 
-In reality your requirements are a little more complex.
+In reality, your requirements will be a little more complex. You should:
 
-* Web Monetized visitors should see an indicator while we're waiting for Web Monetization to intialize
-* We should tell non-Web Monetized visitors that there's exclusive content they can get
+* Show Web-monetized visitors an indicator while they wait for Web Monetization to initialize.
+* Tell non-Web-monetized visitors that there's exclusive content they can get.
 
 This means there's three states in total:
 
-* Show a call to action to a non-Web Monetized visitor
-* Show a loading message to a Web Monetized visitor
-* Show exclusive content to a Web Monetized visitor
+* Show a call-to-action to a non-Web-monetized visitor
+* Show a loading message to a Web-monetized visitor
+* Show exclusive content to a Web-monetized visitor
 
 ### Code
 
@@ -156,26 +156,30 @@ This means there's three states in total:
 </body>
 ```
 
-[_You can view this example page here_](/examples/show.html).
-
-Try loading this page with Web Monetization enabled to see it load the
-exclusive content. Open in in an private window to see what it looks like
+Try loading the example page with Web Monetization enabled to see it load the
+exclusive content. Open it in a private window to see what it looks like
 without Web Monetization.
+
+[_You can view the example page here_](/examples/show.html).
 
 ### How Does it Work?
 
 We have three functions to activate our three different states: `showLoading`
-displays the loader, `showCTA` displays the CTA to get Web Monetized, and
+displays the loader, `showCTA` displays the call-to-action to get Web-monetized, and
 `showExclusiveContent` shows the exclusive content. This works just like the
-[basic example](#basic-example), where we turn the `hidden` class on/off for
+[basic example](#a-basic-example) where we turn the `hidden` class on/off for
 our `div`s.
+
+When the page loads, the first thing we do is check whether Web Monetization
+exists in the visitor's browser.
 
 ```js
 window.addEventListener('load', () => {
 ```
 
-When the page loads in the first thing we do is check whether Web Monetization
-exists in the visitor's browser.
+If the visitor doesn't have Web Monetization, then we show them the CTA right
+away. If the visitor does have Web Monetization, we show them the loader
+right away.
 
 ```js
   if (!document.monetization) {
@@ -185,9 +189,9 @@ exists in the visitor's browser.
   }
 ```
 
-If the visitor does not have Web Monetization then we show them the CTA right
-away. If the vistor does have Web Monetization then we show them the loader
-right away.
+When the visitor is Web-monetized, we also listen for the
+`monetizationstart` event. Just like the previous example, this event will show
+the exclusive content when it's triggered and hide the other `div`s.
 
 ```js
 if (document.monetization) {
@@ -196,8 +200,3 @@ if (document.monetization) {
   })
 }
 ```
-
-If the visitor is Web Monetized then we're also listening for the
-`monetizationstart` event. Just like the previous example this event will show
-the exclusive content when it's triggered, and make sure the other `div`s are
-hidden.

--- a/docs/exclusive-content.md
+++ b/docs/exclusive-content.md
@@ -22,6 +22,7 @@ exclusive content that only shows up for Web Monetized visitors:
 
 ```html
 <head>
+  <!-- this should be set to your own payment pointer -->
   <meta name="monetization" content="$twitter.xrptipbot.com/Interledger">
 
   <style>
@@ -99,6 +100,7 @@ This means there's three states in total:
 
 ```html
 <head>
+  <!-- this should be set to your own payment pointer -->
   <meta name="monetization" content="$twitter.xrptipbot.com/Interledger">
 
   <style>

--- a/docs/exclusive-content.md
+++ b/docs/exclusive-content.md
@@ -1,14 +1,18 @@
 ---
-id: show-content
-title: Show Content
-sidebar_label: Show Content
+id: exclusive-content
+title: Exclusive Content
+sidebar_label: Exclusive Content
 ---
+
+One of the perks of Web Monetization is that its JavaScript API can be used to
+make your page respond to Web Monetization. You can reward the people who
+support your site by giving Web Monetized viewers exclusive content.
+
 
 ## A Basic Example
 
-Showing and hiding content depending on whether a visitor is Web-Monetized is
-easy! This is a very simple example of exclusive content that only shows up
-for Web Monetized visitors:
+Web Monetization makes exclusive content easy! This is a very simple example of
+exclusive content that only shows up for Web Monetized visitors:
 
 > **Careful!** These examples hide content on the client side. A clever user could pretend to be Web Monetized by using the developer console. Examples on how to verify Web Monetization from the server side will come soon.
 
@@ -74,7 +78,7 @@ the state goes from `pending` to `started`.
 Finally we select our exclusive content element and make it visible. We defined
 a CSS class that made it hidden, so removing that class will make it visible.
 If you want to do something else when Web Monetization starts, you can replace
-this line. You can trigger any javascript so the sky's the limit.
+this line. You can trigger any JavaScript so the sky's the limit.
 
 ## A Complete Example
 

--- a/docs/exclusive-content.md
+++ b/docs/exclusive-content.md
@@ -20,7 +20,7 @@ exclusive content that only shows up for Web Monetized visitors:
 
 ```html
 <head>
-  <meta name="monetization" content="$twitter.xrptipbot.com/Coil">
+  <meta name="monetization" content="$twitter.xrptipbot.com/Interledger">
 
   <style>
     .hidden {
@@ -97,7 +97,7 @@ This means there's three states in total:
 
 ```html
 <head>
-  <meta name="monetization" content="$twitter.xrptipbot.com/Coil">
+  <meta name="monetization" content="$twitter.xrptipbot.com/Interledger">
 
   <style>
     .hidden {

--- a/docs/exclusive-content.md
+++ b/docs/exclusive-content.md
@@ -14,7 +14,9 @@ support your site by giving Web Monetized viewers exclusive content.
 Web Monetization makes exclusive content easy! This is a very simple example of
 exclusive content that only shows up for Web Monetized visitors:
 
-> **Careful!** These examples hide content on the client side. A clever user could pretend to be Web Monetized by using the developer console. Examples on how to verify Web Monetization from the server side will come soon.
+> **Careful!** These examples hide content on the client side. A clever user
+> could pretend to be Web Monetized by using the developer console. Examples on
+> how to verify Web Monetization from the server side will come soon.
 
 ### Code
 

--- a/docs/remove-ads.md
+++ b/docs/remove-ads.md
@@ -5,10 +5,10 @@ sidebar_label: Remove Ads
 ---
 
 Removing ads is a great way to thank the people who support your site. You can
-make sure that Web Monetized visitors have a smooth experience without forgoing
+make sure Web-monetized visitors have a smooth experience without forgoing
 monetization of the rest of your visitors.
 
-Here's an example page that removes its ads for Web Monetized visitors:
+Here's an example page that removes its ads for Web-monetized visitors:
 
 ## Code
 
@@ -57,21 +57,23 @@ Here's an example page that removes its ads for Web Monetized visitors:
 </body>
 ```
 
-[_You can view this example page here_](/examples/remove_ads.html).
-
 Users who visit the site without Web Monetization will see ads appear as soon as the page loads.
 
-If you have Web Monetization in your browser then it won't show the ads
-immediately. You have a three second grace period for Web Monetization to
+[_You can view the example page here_](/examples/remove_ads.html).
+
+Users who have Web Monetization in their browser won't see the ads
+immediately. There's a three-second grace period for Web Monetization to
 initialize.
 
-* If Web Monetization initializes before the three seconds are up then you
-  never see ads.
-* Once the three seconds are up the ads will load into the page.
-* If Web Monetization initializes any time after the three seconds are up the
-  ads will be removed.
+If Web Monetization:
+
+* Initializes before the three seconds are up, the ads never appear.
+* Fails to initialize within three seconds, the ads will load into the page.
+* Initializes any time after the three seconds are up, the ads will be removed.
 
 ## How Does it Work?
+
+This works a little bit differently from the [exclusive content example](/docs/exclusive-content). The ad is not added to the page at all until you decide to show ads. That means images and trackers are not loaded for Web-monetized visitors _(although in the example we're only loading an annoying `<marquee>` tag)_.
 
 ```js
 const adCode = 'Ad! <marquee width=200>Buy product A!</marquee> Ad!'
@@ -80,7 +82,11 @@ function showAds () {
 }
 ```
 
-This works a little bit differently from the [exclusive content example](/docs/exclusive-contnt). The ad is not added to the page at all until we decide to show ads. That means images and trackers will not be loaded for Web Monetized visitors _(although in the example we're only loading an annoying `<marquee>` tag)_.
+If the visitor has Web Monetization, then we bind the `monetizationstart` event.
+This triggers the removal of ads once Web Monetization initializes.
+
+The `hasPaid` variable is used in the timer to see whether Web
+Monetization has already initialized when the grace period is over.
 
 ```
 let hasPaid = false
@@ -92,11 +98,11 @@ if (document.monetization) {
 }
 ```
 
-If the visitor has Web Monetization then we bind the `monetizationstart` event.
-This triggers the removal of ads once Web Monetization intializes.
-
-Our `hasPaid` variable will be used in our timer to see whether Web
-Monetization has already initialized when the grace period is over.
+As soon as the page loads, any visitor who does not have Web Monetization
+(`!document.monetization`) sees ads immediately. If the visitor _does_ have Web
+Monetization, the three-second timer starts. We check whether the
+`monetizationstart` event has fired when the timer is up. If Web Monetization
+hasn't initialized, the visitor is shown the ads.
 
 ```js
 window.addEventListener('load', () => {
@@ -112,15 +118,7 @@ window.addEventListener('load', () => {
 })
 ```
 
-As soon as the page loads, any visitor who does not have Web Monetization
-(`!document.monetization`) sees ads immediately.
-
-If the visitor _does_ have Web Moentization we start our three second timer.
-When the timer is up we check whether the `monetizationstart` event has fired.
-If Web Monetization hasn't initialized, we show them the ads.
-
 > You might think of using `document.monetization.state` instead of remembering
-> `hasPaid`. But the state can go back to being stopped or pending if the user
-> backgrounds the tab. If they background your tab when the 3 seconds are over
-> then a legitimately Web Monetizated user might would get shown ads! So
-> keeping a `hasPaid` variable is better.
+> `hasPaid`. But, the state can go back to being `stopped` or `pending` if the user
+> backgrounds the tab. If they background your tab when the three seconds are over,
+> then a legitimately Web-monetized user might be shown ads! Keeping a `hasPaid` variable is a better practice.

--- a/docs/remove-ads.md
+++ b/docs/remove-ads.md
@@ -1,0 +1,131 @@
+---
+id: remove-ads
+title: Remove Ads
+sidebar_label: Remove Ads
+---
+
+Removing ads is a great way to thank the people who support your site. You can
+make sure that Web Monetized visitors have a smooth experience without forgoing
+monetization of the rest of your visitors.
+
+Here's an example page that removes its ads for Web Monetized visitors:
+
+## Code
+
+```html
+<head>
+  <meta name="monetization" content="$twitter.xrptipbot.com/Interledger">
+
+  <style>
+    .hidden {
+      display: none;
+    }
+  </style>
+
+  <script>
+    const adCode = 'Ad! <marquee width=200>Buy product A!</marquee> Ad!'
+    function showAds () {
+      document.getElementById('ad').innerHTML = adCode
+    }
+
+    function removeAds () {
+      document.getElementById('ad').remove()
+    }
+
+    let hasPaid = false
+    if (document.monetization) {
+      document.monetization.addEventListener('monetizationstart', () => {
+        hasPaid = true
+        removeAds()
+      })
+    }
+
+    window.addEventListener('load', () => {
+      if (!document.monetization) {
+        showAds()
+      } else {
+        setTimeout(() => {
+          if (!hasPaid) {
+            showAds()
+          }
+        }, 3000)
+      }
+    })
+  </script>
+</head>
+
+<body>
+  <div id="ad">
+  </div>
+
+  Here's some real content.
+</body>
+```
+
+[_You can view this example page here_](/examples/remove_ads.html).
+
+Users who visit the site without Web Monetization will see ads appear as soon as the page loads.
+
+If you have Web Monetization in your browser then it won't show the ads
+immediately. You have a three second grace period for Web Monetization to
+initialize.
+
+* If Web Monetization initializes before the three seconds are up then you
+  never see ads.
+* Once the three seconds are up the ads will load into the page.
+* If Web Monetization initializes any time after the three seconds are up the
+  ads will be removed.
+
+## How Does it Work?
+
+```js
+const adCode = 'Ad! <marquee width=200>Buy product A!</marquee> Ad!'
+function showAds () {
+  document.getElementById('ad').innerHTML = adCode
+}
+```
+
+This works a little bit differently from the [exclusive content example](/docs/exclusive-contnt). The ad is not added to the page at all until we decide to show ads. That means images and trackers will not be loaded for Web Monetized visitors _(although in the example we're only loading an annoying `<marquee>` tag)_.
+
+```
+let hasPaid = false
+if (document.monetization) {
+  document.monetization.addEventListener('monetizationstart', () => {
+    hasPaid = true
+    removeAds()
+  })
+}
+```
+
+If the visitor has Web Monetization then we bind the `monetizationstart` event.
+This triggers the removal of ads once Web Monetization intializes.
+
+Our `hasPaid` variable will be used in our timer to see whether Web
+Monetization has already initialized when the grace period is over.
+
+```js
+window.addEventListener('load', () => {
+  if (!document.monetization) {
+    showAds()
+  } else {
+    setTimeout(() => {
+      if (!hasPaid) {
+        showAds()
+      }
+    }, 3000)
+  }
+})
+```
+
+As soon as the page loads, any visitor who does not have Web Monetization
+(`!document.monetization`) sees ads immediately.
+
+If the visitor _does_ have Web Moentization we start our three second timer.
+When the timer is up we check whether the `monetizationstart` event has fired.
+If Web Monetization hasn't initialized, we show them the ads.
+
+> You might think of using `document.monetization.state` instead of remembering
+> `hasPaid`. But the state can go back to being stopped or pending if the user
+> backgrounds the tab. If they background your tab when the 3 seconds are over
+> then a legitimately Web Monetizated user might would get shown ads! So
+> keeping a `hasPaid` variable is better.

--- a/docs/remove-ads.md
+++ b/docs/remove-ads.md
@@ -14,6 +14,7 @@ Here's an example page that removes its ads for Web Monetized visitors:
 
 ```html
 <head>
+  <!-- this should be set to your own payment pointer -->
   <meta name="monetization" content="$twitter.xrptipbot.com/Interledger">
 
   <script>

--- a/docs/remove-ads.md
+++ b/docs/remove-ads.md
@@ -16,12 +16,6 @@ Here's an example page that removes its ads for Web Monetized visitors:
 <head>
   <meta name="monetization" content="$twitter.xrptipbot.com/Interledger">
 
-  <style>
-    .hidden {
-      display: none;
-    }
-  </style>
-
   <script>
     const adCode = 'Ad! <marquee width=200>Buy product A!</marquee> Ad!'
     function showAds () {

--- a/docs/show-content.md
+++ b/docs/show-content.md
@@ -1,0 +1,187 @@
+---
+id: show-content
+title: Show Content
+sidebar_label: Show Content
+---
+
+## A Basic Example
+
+Showing and hiding content depending on whether a visitor is Web-Monetized is
+easy! This is a very simple example of exclusive content that only shows up
+for Web Monetized visitors:
+
+> **Careful!** These examples hide content on the client side. A clever user could pretend to be Web Monetized by using the developer console. Examples on how to verify Web Monetization from the server side will come soon.
+
+### Code
+
+```html
+<head>
+  <meta name="monetization" content="$twitter.xrptipbot.com/Coil">
+
+  <style>
+    .hidden {
+      display: none;
+    }
+  </style>
+
+  <script>
+    if (document.monetization) {
+      document.monetization.addEventListener('monetizationstart', () => {
+        document.getElementById('exclusive').classList.remove('hidden')
+      })
+    }
+  </script>
+</head>
+
+<body>
+  <div id="exclusive" class="hidden">
+    Here's some exclusive content!
+  </div>
+</body>
+```
+
+If you view this content with Web Monetization enabled then it will show
+"Here's some exclusive content!" once Web Monetization initializes. If you view
+it without Web Monetization then you won't see anything.
+
+### How Does it Work?
+
+There's only three things this code does. The code is encompassed in the `<script>`
+tag.
+
+```js
+if (document.monetization) {
+```
+
+First, we check whether document.monetization exists in this browser. If it
+does not exist then we can't listen for the `monetizationstart` event to tell
+us when Web Monetization initializes.
+
+```js
+  document.monetization.addEventListener('monetizationstart', () => {
+```
+
+Next we add an event listener to the `document.monetization` object. The
+`monetizationstart` event is emitted when Web Monetization initializes and
+the state goes from `pending` to `started`.
+
+```js
+      document.getElementById('exclusive').classList.remove('hidden')
+```
+
+Finally we select our exclusive content element and make it visible. We defined
+a CSS class that made it hidden, so removing that class will make it visible.
+If you want to do something else when Web Monetization starts, you can replace
+this line. You can trigger any javascript so the sky's the limit.
+
+## A Complete Example
+
+In reality your requirements are a little more complex.
+
+* Web Monetized visitors should see an indicator while we're waiting for Web Monetization to intialize
+* We should tell non-Web Monetized visitors that there's exclusive content they can get
+
+This means there's three states in total:
+
+* Show a call to action to a non-Web Monetized visitor
+* Show a loading message to a Web Monetized visitor
+* Show exclusive content to a Web Monetized visitor
+
+### Code
+
+```html
+<head>
+  <meta name="monetization" content="$twitter.xrptipbot.com/Coil">
+
+  <style>
+    .hidden {
+      display: none;
+    }
+  </style>
+
+  <script>
+    function showExclusiveContent () {
+      document.getElementById('exclusive').classList.remove('hidden')
+      document.getElementById('loading').classList.add('hidden')
+      document.getElementById('cta').classList.add('hidden')
+    }
+
+    function showCTA () {
+      document.getElementById('loading').classList.add('hidden')
+      document.getElementById('cta').classList.remove('hidden')
+    }
+
+    function showLoading () {
+      document.getElementById('loading').classList.remove('hidden')
+    }
+
+    if (document.monetization) {
+      document.monetization.addEventListener('monetizationstart', () => {
+        showExclusiveContent()
+      })
+    }
+
+    window.addEventListener('load', () => {
+      if (!document.monetization) {
+        showCTA()
+      } else {
+        showLoading()
+      }
+    })
+  </script>
+</head>
+
+<body>
+  <div id="loading" class="hidden">
+    Loading exclusive content...
+  </div>
+
+  <div id="exclusive" class="hidden">
+    Here's some exclusive content!
+  </div>
+
+  <div id="cta" class="hidden">
+    Please install a Web Monetization extension to support me!
+  </div>
+</body>
+```
+
+### How Does it Work?
+
+We have three functions to activate our three different states: `showLoading`
+displays the loader, `showCTA` displays the CTA to get Web Monetized, and
+`showExclusiveContent` shows the exclusive content. This works just like the
+[basic example](#basic-example), where we turn the `hidden` class on/off for
+our `div`s.
+
+```js
+window.addEventListener('load', () => {
+```
+
+When the page loads in the first thing we do is check whether Web Monetization
+exists in the visitor's browser.
+
+```js
+  if (!document.monetization) {
+    showCTA()
+  } else {
+    showLoading()
+  }
+```
+
+If the visitor does not have Web Monetization then we show them the CTA right
+away. If the vistor does have Web Monetization then we show them the loader
+right away.
+
+```js
+if (document.monetization) {
+  document.monetization.addEventListener('monetizationstart', () => {
+    showExclusiveContent()
+  })
+}
+```
+
+If the visitor is Web Monetized then we're also listening for the
+`monetizationstart` event. Just like the previous example this event will show
+the exclusive content when it's triggered, and make sure the other `div`s are
+hidden.

--- a/docs/show-content.md
+++ b/docs/show-content.md
@@ -40,6 +40,8 @@ for Web Monetized visitors:
 </body>
 ```
 
+[_You can view this example page here_](/examples/show_simple.html).
+
 If you view this content with Web Monetization enabled then it will show
 "Here's some exclusive content!" once Web Monetization initializes. If you view
 it without Web Monetization then you won't see anything.
@@ -145,6 +147,12 @@ This means there's three states in total:
   </div>
 </body>
 ```
+
+[_You can view this example page here_](/examples/show.html).
+
+Try loading this page with Web Monetization enabled to see it load the
+exclusive content. Open in in an private window to see what it looks like
+without Web Monetization.
 
 ### How Does it Work?
 

--- a/docs/start-stop.md
+++ b/docs/start-stop.md
@@ -4,13 +4,13 @@ title: Start/Stop Monetization
 sidebar_label: Start/Stop Monetization
 ---
 
-Sometimes you don't want your entire site to be web monetized. The easiest way
+Sometimes you don't want your entire site to be Web-monetized. The easiest way
 to do this is to just include the Web Monetization meta tag on the pages you
 want to monetize. But if you want to turn Web Monetization on and off
-dynamically then you can do that too.
+dynamically, you can do that too!
 
-This example page shows how to turn Web Monetization on or off dynamically,
-when a visitor clicks a button.
+This example page shows how to turn Web Monetization on and off dynamically, in
+response to a visitor clicking a button.
 
 ## Code
 
@@ -68,16 +68,24 @@ when a visitor clicks a button.
 </body>
 ```
 
-[_You can view this example page here_](/examples/start-stop.html).
+If you view this in a Web-monetized browser, you can see the monetization state
+and control it with the _Stop Monetization_ and _Start Monetization_ buttons.
 
-If you view this in a Web Monetized browser you can see the monetization state
-and control it with the "Stop Monetization" and "Start Monetization" buttons.
+[_You can view the example page here_](/examples/start-stop.html).
 
-When you click "Stop Monetization," the state will immediately go to "stopped."
-If you click "Start Monetization," the state will move to "pending," and then
-proceed to "started" once Web Monetization initializes.
+When you click _Stop Monetization_, the state will immediately go to `stopped`.
+When you click _Start Monetization_, the state will move to `pending`, and then
+proceed to `started` after Web Monetization initializes.
 
 ## How Does it Work?
+
+To display the current monetization state on the page, we bind the
+three monetization state events: `monetizationstop`, `monetizationpending`, and
+`monetizationstart`. Each time one of them fires we display the current
+monetization state.
+
+> This isn't required to start and stop monetization but it helps visualize it on
+> the example page.
 
 ```js
 function showMonetizationState () {
@@ -91,13 +99,9 @@ if (document.monetization) {
 }
 ```
 
-In order to display the current monetization state on the page, we bind the
-three monetization state events: `monetizationstop`, `monetizationpending`, and
-`monetizationstart`. Each time one of them fires we display the current
-monetization state.
-
-This isn't required to start and stop monetization but it helps visualize it on
-the example page.
+When the page loads we set an initial state. If the visitor doesn't have Web
+Monetization (`document.monetization` is not defined), we say _Not enabled in
+browser._ Otherwise, we display the current monetization state.
 
 ```js
 window.addEventListener('load', () => {
@@ -108,17 +112,17 @@ window.addEventListener('load', () => {
   }
 ```
 
-When the page loads we set an initial state. If the user doesn't have Web
-Monetization (`document.monetization` is not defined), we say "Not enabled in
-browser." Otherwise we display the current monetization state.
+We need to grab the meta tag's element object in order to add and remove it.
+The query selector, `meta[name="monetization"]`, selects a `<meta>` tag with
+a `name` attribute of `monetization` (the Web Monetization meta tag).
 
 ```js
 const monetizationTag = document.querySelector('meta[name="monetization"]')
 ```
 
-We need to grab the meta tag's element object in order to add and remove it.
-The query selector, `meta[name="monetization"]` selects a `<meta>` tag with
-a `"name"` attribute of `monetization`, the Web Monetization meta tag.
+When the _Stop_ button is clicked, we call `remove()` on the monetization tag
+element. Your Web Monetization extension will pick up this change and stop
+monetization right away.
 
 ```js
 stopButton.addEventListener('click', () => {
@@ -129,9 +133,9 @@ stopButton.addEventListener('click', () => {
 })
 ```
 
-When the stop button is clicked, we call `remove()` on the monetization tag
-element. Your Web Monetization extension will pick up this change and stop
-monetization right away.
+When the _Start_ button is clicked, we append the monetization tag to the
+document's head. Your Web Monetization extension will pick up this change and
+begin initializing Web Mone tization.
 
 ```js
 startButton.addEventListener('click', () => {
@@ -141,7 +145,3 @@ startButton.addEventListener('click', () => {
   startButton.disabled = true
 })
 ```
-
-When the start button is clicked, we append the monetization tag to the
-document's head. Your Web Monetization extension will pick up this change and
-begin initializing Web Monetization.

--- a/docs/start-stop.md
+++ b/docs/start-stop.md
@@ -1,0 +1,147 @@
+---
+id: start-stop
+title: Start/Stop Monetization
+sidebar_label: Start/Stop Monetization
+---
+
+Sometimes you don't want your entire site to be web monetized. The easiest way
+to do this is to just include the Web Monetization meta tag on the pages you
+want to monetize. But if you want to turn Web Monetization on and off
+dynamically then you can do that too.
+
+This example page shows how to turn Web Monetization on or off dynamically,
+when a visitor clicks a button.
+
+## Code
+
+```html
+<head>
+  <!-- the "content" should be set to your own payment pointer -->
+  <meta name="monetization" content="$twitter.xrptipbot.com/Interledger">
+
+  <script>
+    function showMonetizationState () {
+      document.getElementById('state').innerText = document.monetization.state
+    }
+
+    if (document.monetization) {
+      document.monetization.addEventListener('monetizationstop', showMonetizationState)
+      document.monetization.addEventListener('monetizationpending', showMonetizationState)
+      document.monetization.addEventListener('monetizationstart', showMonetizationState)
+    }
+
+    window.addEventListener('load', () => {
+      if (!document.monetization) {
+        document.getElementById('state').innerText = 'Not enabled in browser'
+      } else {
+        showMonetizationState()
+      }
+
+      const stopButton = document.getElementById('stop-button')
+      const startButton = document.getElementById('start-button')
+      const monetizationTag = document.querySelector('meta[name="monetization"]')
+
+      stopButton.addEventListener('click', () => {
+        monetizationTag.remove()
+
+        stopButton.disabled = true
+        startButton.disabled = false
+      })
+
+      startButton.addEventListener('click', () => {
+        document.head.appendChild(monetizationTag)
+
+        stopButton.disabled = false
+        startButton.disabled = true
+      })
+    })
+  </script>
+</head>
+
+<body>
+  <div id="loading">
+    Current Monetization State: <span id="state"></span>
+  </div>
+
+  <button id="stop-button">Stop Monetization</button>
+  <button id="start-button" disabled>Start Monetization</button>
+</body>
+```
+
+[_You can view this example page here_](/examples/start-stop.html).
+
+If you view this in a Web Monetized browser you can see the monetization state
+and control it with the "Stop Monetization" and "Start Monetization" buttons.
+
+When you click "Stop Monetization," the state will immediately go to "stopped."
+If you click "Start Monetization," the state will move to "pending," and then
+proceed to "started" once Web Monetization initializes.
+
+## How Does it Work?
+
+```js
+function showMonetizationState () {
+  document.getElementById('state').innerText = document.monetization.state
+}
+
+if (document.monetization) {
+  document.monetization.addEventListener('monetizationstop', showMonetizationState)
+  document.monetization.addEventListener('monetizationpending', showMonetizationState)
+  document.monetization.addEventListener('monetizationstart', showMonetizationState)
+}
+```
+
+In order to display the current monetization state on the page, we bind the
+three monetization state events: `monetizationstop`, `monetizationpending`, and
+`monetizationstart`. Each time one of them fires we display the current
+monetization state.
+
+This isn't required to start and stop monetization but it helps visualize it on
+the example page.
+
+```js
+window.addEventListener('load', () => {
+  if (!document.monetization) {
+    document.getElementById('state').innerText = 'Not enabled in browser'
+  } else {
+    showMonetizationState()
+  }
+```
+
+When the page loads we set an initial state. If the user doesn't have Web
+Monetization (`document.monetization` is not defined), we say "Not enabled in
+browser." Otherwise we display the current monetization state.
+
+```js
+const monetizationTag = document.querySelector('meta[name="monetization"]')
+```
+
+We need to grab the meta tag's element object in order to add and remove it.
+The query selector, `meta[name="monetization"]` selects a `<meta>` tag with
+a `"name"` attribute of `monetization`, the Web Monetization meta tag.
+
+```js
+stopButton.addEventListener('click', () => {
+  monetizationTag.remove()
+
+  stopButton.disabled = true
+  startButton.disabled = false
+})
+```
+
+When the stop button is clicked, we call `remove()` on the monetization tag
+element. Your Web Monetization extension will pick up this change and stop
+monetization right away.
+
+```js
+startButton.addEventListener('click', () => {
+  document.head.appendChild(monetizationTag)
+
+  stopButton.disabled = false
+  startButton.disabled = true
+})
+```
+
+When the start button is clicked, we append the monetization tag to the
+document's head. Your Web Monetization extension will pick up this change and
+begin initializing Web Monetization.

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -9,6 +9,10 @@
         "title": "JavaScript API",
         "sidebar_label": "JavaScript API"
       },
+      "exclusive-content": {
+        "title": "Exclusive Content",
+        "sidebar_label": "Exclusive Content"
+      },
       "explainer": {
         "title": "Web Monetization Explainer",
         "sidebar_label": "Web Monetization"
@@ -32,10 +36,6 @@
       "sending": {
         "title": "Web Monetization Providers",
         "sidebar_label": "Sending Payments"
-      },
-      "show-content": {
-        "title": "Show Content",
-        "sidebar_label": "Show Content"
       },
       "specification": {
         "title": "Draft Web Monetization Specification",

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -48,6 +48,10 @@
       "specification": {
         "title": "Draft Web Monetization Specification",
         "sidebar_label": "Specification"
+      },
+      "start-stop": {
+        "title": "Start/Stop Monetization",
+        "sidebar_label": "Start/Stop Monetization"
       }
     },
     "links": {

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -9,6 +9,10 @@
         "title": "JavaScript API",
         "sidebar_label": "JavaScript API"
       },
+      "counter": {
+        "title": "Micropayment Counter",
+        "sidebar_label": "Micropayment Counter"
+      },
       "exclusive-content": {
         "title": "Exclusive Content",
         "sidebar_label": "Exclusive Content"

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -29,6 +29,10 @@
         "title": "Web Monetization Receivers",
         "sidebar_label": "Receiving Payments"
       },
+      "remove-ads": {
+        "title": "Remove Ads",
+        "sidebar_label": "Remove Ads"
+      },
       "resources": {
         "title": "External Resources",
         "sidebar_label": "External Resources"

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -33,6 +33,10 @@
         "title": "Web Monetization Providers",
         "sidebar_label": "Sending Payments"
       },
+      "show-content": {
+        "title": "Show Content",
+        "sidebar_label": "Show Content"
+      },
       "specification": {
         "title": "Draft Web Monetization Specification",
         "sidebar_label": "Specification"
@@ -46,6 +50,7 @@
     },
     "categories": {
       "Overview": "Overview",
+      "Examples": "Examples",
       "Explainer": "Explainer",
       "More": "More"
     }

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,7 +1,7 @@
 {
   "docs": {
     "Overview": ["getting-started", "api"],
-    "Examples": ["show-content"],
+    "Examples": ["exclusive-content"],
     "Explainer": ["explainer", "receiving", "sending"],
     "More": ["specification", "glossary", "resources"]
   }

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,7 +1,7 @@
 {
   "docs": {
     "Overview": ["getting-started", "api"],
-    "Examples": ["exclusive-content", "remove-ads"],
+    "Examples": ["exclusive-content", "remove-ads", "counter"],
     "Explainer": ["explainer", "receiving", "sending"],
     "More": ["specification", "glossary", "resources"]
   }

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,6 +1,7 @@
 {
   "docs": {
     "Overview": ["getting-started", "api"],
+    "Examples": ["show-content"],
     "Explainer": ["explainer", "receiving", "sending"],
     "More": ["specification", "glossary", "resources"]
   }

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,7 +1,7 @@
 {
   "docs": {
     "Overview": ["getting-started", "api"],
-    "Examples": ["exclusive-content", "remove-ads", "counter"],
+    "Examples": ["exclusive-content", "remove-ads", "counter", "start-stop"],
     "Explainer": ["explainer", "receiving", "sending"],
     "More": ["specification", "glossary", "resources"]
   }

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,7 +1,7 @@
 {
   "docs": {
     "Overview": ["getting-started", "api"],
-    "Examples": ["exclusive-content"],
+    "Examples": ["exclusive-content", "remove-ads"],
     "Explainer": ["explainer", "receiving", "sending"],
     "More": ["specification", "glossary", "resources"]
   }

--- a/website/static/examples/counter.html
+++ b/website/static/examples/counter.html
@@ -1,0 +1,31 @@
+<head>
+  <meta name="monetization" content="$twitter.xrptipbot.com/Interledger">
+
+  <script>
+    let total = 0
+    let scale
+
+    if (document.monetization) {
+      document.monetization.addEventListener('monetizationprogress', ev => {
+        // initialize currency and scale on first progress event
+        if (total === 0) {
+          scale = ev.detail.assetScale
+          document.getElementById('currency').innerText = ev.detail.assetCode
+        }
+
+        total += Number(ev.detail.amount)
+
+        const formatted = (total * Math.pow(10, -scale)).toFixed(scale)
+        document.getElementById('total').innerText = formatted
+      })
+    }
+  </script>
+</head>
+
+<body>
+  <p>
+    Thanks to you, I've made
+    <span id="total">nothing (yet)</span>
+    <span id="currency"></span>
+  </p>
+</body>

--- a/website/static/examples/remove_ads.html
+++ b/website/static/examples/remove_ads.html
@@ -1,0 +1,47 @@
+<head>
+  <meta name="monetization" content="$twitter.xrptipbot.com/Coil">
+
+  <style>
+    .hidden {
+      display: none;
+    }
+  </style>
+
+  <script>
+    const adCode = 'Ad! <marquee width=200>Buy product A!</marquee> Ad!'
+    function showAds () {
+      document.getElementById('ad').innerHTML = adCode
+    }
+
+    function removeAds () {
+      document.getElementById('ad').remove()
+    }
+
+    let hasPaid = false
+    if (document.monetization) {
+      document.monetization.addEventListener('monetizationstart', () => {
+        hasPaid = true
+        removeAds()
+      })
+    }
+
+    window.addEventListener('load', () => {
+      if (!document.monetization) {
+        showAds()
+      } else {
+        setTimeout(() => {
+          if (!hasPaid) {
+            showAds()
+          }
+        }, 3000)
+      }
+    })
+  </script>
+</head>
+
+<body>
+  <div id="ad">
+  </div>
+
+  Here's some real content.
+</body>

--- a/website/static/examples/remove_ads.html
+++ b/website/static/examples/remove_ads.html
@@ -1,5 +1,5 @@
 <head>
-  <meta name="monetization" content="$twitter.xrptipbot.com/Coil">
+  <meta name="monetization" content="$twitter.xrptipbot.com/Interledger">
 
   <style>
     .hidden {

--- a/website/static/examples/remove_ads.html
+++ b/website/static/examples/remove_ads.html
@@ -1,12 +1,6 @@
 <head>
   <meta name="monetization" content="$twitter.xrptipbot.com/Interledger">
 
-  <style>
-    .hidden {
-      display: none;
-    }
-  </style>
-
   <script>
     const adCode = 'Ad! <marquee width=200>Buy product A!</marquee> Ad!'
     function showAds () {

--- a/website/static/examples/show.html
+++ b/website/static/examples/show.html
@@ -1,5 +1,5 @@
 <head>
-  <meta name="monetization" content="$twitter.xrptipbot.com/Coil">
+  <meta name="monetization" content="$twitter.xrptipbot.com/Interledger">
 
   <style>
     .hidden {

--- a/website/static/examples/show.html
+++ b/website/static/examples/show.html
@@ -1,0 +1,54 @@
+<head>
+  <meta name="monetization" content="$twitter.xrptipbot.com/Coil">
+
+  <style>
+    .hidden {
+      display: none;
+    }
+  </style>
+
+  <script>
+    function showExclusiveContent () {
+      document.getElementById('exclusive').classList.remove('hidden')
+      document.getElementById('loading').classList.add('hidden')
+      document.getElementById('cta').classList.add('hidden')
+    }
+
+    function showCTA () {
+      document.getElementById('loading').classList.add('hidden')
+      document.getElementById('cta').classList.remove('hidden')
+    }
+
+    function showLoading () {
+      document.getElementById('loading').classList.remove('hidden')
+    }
+
+    if (document.monetization) {
+      document.monetization.addEventListener('monetizationstart', () => {
+        showExclusiveContent()
+      })
+    }
+
+    window.addEventListener('load', () => {
+      if (!document.monetization) {
+        showCTA()
+      } else {
+        showLoading()
+      }
+    })
+  </script>
+</head>
+
+<body>
+  <div id="loading" class="hidden">
+    Loading exclusive content...
+  </div>
+
+  <div id="exclusive" class="hidden">
+    Here's some exclusive content!
+  </div>
+
+  <div id="cta" class="hidden">
+    Please install a Web Monetization extension to support me!
+  </div>
+</body>

--- a/website/static/examples/show_simple.html
+++ b/website/static/examples/show_simple.html
@@ -1,0 +1,23 @@
+<head>
+  <meta name="monetization" content="$twitter.xrptipbot.com/Coil">
+
+  <style>
+    .hidden {
+      display: none;
+    }
+  </style>
+
+  <script>
+    if (document.monetization) {
+      document.monetization.addEventListener('monetizationstart', () => {
+        document.getElementById('exclusive').classList.remove('hidden')
+      })
+    }
+  </script>
+</head>
+
+<body>
+  <div id="exclusive" class="hidden">
+    Here's some exclusive content!
+  </div>
+</body>

--- a/website/static/examples/show_simple.html
+++ b/website/static/examples/show_simple.html
@@ -1,5 +1,5 @@
 <head>
-  <meta name="monetization" content="$twitter.xrptipbot.com/Coil">
+  <meta name="monetization" content="$twitter.xrptipbot.com/Interledger">
 
   <style>
     .hidden {

--- a/website/static/examples/start-stop.html
+++ b/website/static/examples/start-stop.html
@@ -1,0 +1,50 @@
+<head>
+  <meta name="monetization" content="$twitter.xrptipbot.com/Interledger">
+
+  <script>
+    function showMonetizationState () {
+      document.getElementById('state').innerText = document.monetization.state
+    }
+
+    if (document.monetization) {
+      document.monetization.addEventListener('monetizationstop', showMonetizationState)
+      document.monetization.addEventListener('monetizationpending', showMonetizationState)
+      document.monetization.addEventListener('monetizationstart', showMonetizationState)
+    }
+
+    window.addEventListener('load', () => {
+      if (!document.monetization) {
+        document.getElementById('state').innerText = 'Not enabled in browser'
+      } else {
+        showMonetizationState()
+      }
+
+      const stopButton = document.getElementById('stop-button')
+      const startButton = document.getElementById('start-button')
+      const monetizationTag = document.querySelector('meta[name="monetization"]')
+
+      stopButton.addEventListener('click', () => {
+        monetizationTag.remove()
+
+        stopButton.disabled = true
+        startButton.disabled = false
+      })
+
+      startButton.addEventListener('click', () => {
+        document.head.appendChild(monetizationTag)
+
+        stopButton.disabled = false
+        startButton.disabled = true
+      })
+    })
+  </script>
+</head>
+
+<body>
+  <div id="loading">
+    Current Monetization State: <span id="state"></span>
+  </div>
+
+  <button id="stop-button">Stop Monetization</button>
+  <button id="start-button" disabled>Start Monetization</button>
+</body>


### PR DESCRIPTION
Added some examples on how to do exclusive content with Web Monetization. Also included the examples in the static folder so users can try them out.

edit: also added a remove ads example
edit: added example counter and start/stop wm example