### PR TITLE
fix: make spelling consistent with rest of the page

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -146,7 +146,7 @@ class Index extends React.Component {
     const Tools = () =>
       <CardBlock id="tools">
         <h2>Web Monetization Tools</h2>
-        <p>These tools enable webmonetization features</p>
+        <p>These tools enable Web Monetization features</p>
         <CardSet cards={siteConfig.tools} />
       </CardBlock>
 


### PR DESCRIPTION
Fabian made me aware of the fact that it is "Web Monetization" on the entire page.
Sorry for not paying attention to detail. 